### PR TITLE
Rename to 'Qt Widgets Designer'

### DIFF
--- a/io.qt.Designer.desktop
+++ b/io.qt.Designer.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Qt Designer
+Name=Qt Widgets Designer
 GenericName=Interface Designer
 Comment=Design GUIs for Qt applications
 Comment[de]=Erstelle GUIs for Qt Anwendungen

--- a/io.qt.Designer.metainfo.xml
+++ b/io.qt.Designer.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <!--Created with jdAppStreamEdit 9.2-->
   <id>io.qt.Designer</id>
-  <name>Qt Designer</name>
+  <name>Qt Widgets Designer</name>
   <summary>Design GUIs for Qt applications</summary>
   <summary xml:lang="de">Erstelle GUIs for Qt Anwendungen</summary>
   <developer id="org.qt-project">
@@ -12,8 +12,8 @@
   <project_license>LGPL-3.0-only</project_license>
   <project_group>Qt</project_group>
   <description>
-    <p>Qt Designer lets you created and edit .ui files for your Qt Widgets Application</p>
-    <p xml:lang="de">Mit Qt Designer kannst du .ui Dateien für deine Qt Anwendung erstellen und bearbeiten</p>
+    <p>Qt Widgets Designer lets you created and edit .ui files for your Qt Widgets Application</p>
+    <p xml:lang="de">Mit Qt Widgets Designer kannst du .ui Dateien für deine Qt Anwendung erstellen und bearbeiten</p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
'Qt Designer' is called 'Qt Widgets Designer' since Qt 6.8:

https://qt-project.atlassian.net/browse/QTBUG-122253
https://doc.qt.io/qt-6/qtdesigner-manual.html